### PR TITLE
Fix typo in variable name

### DIFF
--- a/amine/process_real_network.py
+++ b/amine/process_real_network.py
@@ -391,7 +391,7 @@ def process(
                 groups_output_file, "w"
             ) as outfile_groups:
                 outfile.write("module_nb, genes, s score,pvalue\n")
-                for ctr, result in enumerate(result):
+                for ctr, result in enumerate(results):
                     outfile.write(
                         "{},{},{},{}\n".format(
                             ctr + 1,


### PR DESCRIPTION
The variable `result` is unbound. This leads to an `UnboundLocalError` when the suffix of the output file is not equal to `.xlsx`.